### PR TITLE
Refactor agent report API

### DIFF
--- a/lib/snowman-io/api.rb
+++ b/lib/snowman-io/api.rb
@@ -7,12 +7,13 @@ require 'snowman-io/api/apps'
 require 'snowman-io/api/info'
 require 'snowman-io/api/metrics'
 require 'snowman-io/api/checks'
+require 'snowman-io/api/agent'
 
 module SnowmanIO
   module API
     class Root < Grape::API
       include AuthHelpers
-      prefix :api
+      default_format :json
       format :json
       default_error_formatter :json
 
@@ -27,6 +28,9 @@ module SnowmanIO
         end
       end
 
+      mount Agent
+
+      prefix :api
       mount Users
       mount Apps
       mount Info

--- a/lib/snowman-io/api/agent.rb
+++ b/lib/snowman-io/api/agent.rb
@@ -1,0 +1,25 @@
+module SnowmanIO
+  module API
+    class Agent < Grape::API
+      namespace :agent do
+
+        desc "Report metrics from agent"
+        params do
+          requires :token, type: String
+          optional :metrics, type: Array
+        end
+        post "metrics" do
+          if app = App.where(token: params[:token]).first
+            params[:metrics].each do |metric|
+              app.register_metric_value(metric["name"], metric["kind"], metric["value"].to_f, Time.now)
+            end
+            "OK"
+          else
+            "WRONG APP"
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/snowman-io/web.rb
+++ b/lib/snowman-io/web.rb
@@ -15,18 +15,6 @@ module SnowmanIO
       "PONG"
     end
 
-    post '/agent/metrics' do
-      payload = JSON.load(request.body.read)
-      if app = App.where(token: payload["token"]).first
-        payload["metrics"].each do |metric|
-          app.register_metric_value(metric["name"], metric["kind"], metric["value"].to_f, Time.now)
-        end
-        "OK"
-      else
-        "WRONG APP"
-      end
-    end
-
     # Ember application
     get '/*' do
       send_file File.expand_path("../ui/index.html", __FILE__)

--- a/ui/app/templates/apps/show/_install.hbs
+++ b/ui/app/templates/apps/show/_install.hbs
@@ -20,5 +20,7 @@ SNOWMANIO_SECRET_TOKEN={{model.token}}
 
 <h2>Send Test Request</h2>
 <pre>
-curl {{baseUrl}}/agent/metrics -d '{"token":"{{model.token}}","metrics":[{"name":"Request","value":0.15,"kind":"request"}]}'
+curl {{baseUrl}}/agent/metrics \
+     -H "Content-Type: application/json" \
+     -d '{"token":"{{model.token}}","metrics":[{"name":"Request","value":0.15,"kind":"request"}]}'
 </pre>


### PR DESCRIPTION
@avakhov should we put agent reporting api to `api` namespace or just leave `agent` namespace only?